### PR TITLE
Add project id option to local json

### DIFF
--- a/command/start.go
+++ b/command/start.go
@@ -19,7 +19,10 @@ func (app *App) CmdStart(c *cli.Context) error {
 	timeEntry.WID = viper.GetInt("wid")
 	if c.IsSet("project-id") {
 		timeEntry.PID = c.Int("project-id")
+	} else if viper.GetInt("pid") != 0 {
+		timeEntry.PID = viper.GetInt("pid")
 	}
+
 	response, err := app.client.PostStartTimeEntry(timeEntry)
 	if err != nil {
 		return err

--- a/local.go
+++ b/local.go
@@ -16,7 +16,13 @@ func CmdLocal(c *cli.Context) error {
 		return err
 	}
 
-	CreateConfig(LocalConfigFilePath(), map[string]int{"wid": wid})
+	var pid int
+
+	if c.IsSet("project-id") {
+		pid = c.Int("project-id")
+	}
+
+	CreateConfig(LocalConfigFilePath(), map[string]int{"wid": wid, "pid": pid})
 
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -75,6 +75,9 @@ func main() {
 			Name:   "local",
 			Usage:  "Set current dir workspace",
 			Action: CmdLocal,
+			Flags: []cli.Flag{
+				projectIDFlag,
+			},
 		},
 		{
 			Name:   "global",


### PR DESCRIPTION
I've added the ability to specify a project id on the local level.  Can be overwritten by passing `--project-id` flag to `toggl start`