### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ GLOBAL OPTIONS:
 To install, use `go get`:
 
 ```bash
-$ go get -d github.com/sachaos/toggl
+$ go get github.com/sachaos/toggl
 ```
 
 ### Register API token


### PR DESCRIPTION
Hello, I've made a tiny change to README.
Most users like me who just want to use this tool should `go get` without -d option, I believe.
I'm completely new to go lang and was little bit confusing, "Hmm, where's toggl executable?" 😅 

Thanks for this tool, it's so useful.
