### PR TITLE
Use api.track.toggl.com for the API instead of www.toggle.com

### DIFF
--- a/lib/client.go
+++ b/lib/client.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	baseURI    = "https://www.toggl.com/api/v8"
+	baseURI    = "https://api.track.toggl.com/api/v8"
 	retryCount = 3
 )
 


### PR DESCRIPTION
www.toggle.com for the API will be dropped after 2021-06-30