### PR TITLE
chore(goreleaser): fix the failure of goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,12 +14,13 @@ builds:
   ldflags:
   - -s -w -X github.com/sachaos/toggl.version={{.Version}}
 archives:
-- replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
+- name_template: >-
+    {{- .ProjectName }}_
+    {{- .Version }}_
+    {{- title .Os }}_
+    {{- if eq .Arch "amd64" }}x86_64
+    {{- else if eq .Arch "386" }}i386
+    {{- else }}{{ .Arch }}{{ end -}}
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
I noticed the latest release v0.6.0 has no pre built binaries as the release workflow failed.

https://github.com/sachaos/toggl/releases/tag/v0.6.0

<img width="335" alt="image" src="https://github.com/sachaos/toggl/assets/13323303/47964794-8ff9-4e8f-976b-11af6ce45054">

https://github.com/sachaos/toggl/actions/runs/8881061491/job/24382541225

```
Run goreleaser/goreleaser-action@v1
✅ GoReleaser version found: v1.25.1
⬇️ Downloading https://github.com/goreleaser/goreleaser/releases/download/v1.25.1/goreleaser_Linux_x86_64.tar.gz...
📦 Extracting GoReleaser...
/usr/bin/tar xz --warning=no-unknown-keyword -C /home/runner/work/_temp/28a838f1-afca-4c05-9b9d-f0edb7982e94 -f /home/runner/work/_temp/f0bd4416-ebfb-407a-b04b-b15019c02fb0
✅ v0.6.0 tag found for commit 'd730e48'
🏃 Running GoReleaser...
/opt/hostedtoolcache/goreleaser-action/1.25.1/x64/goreleaser release --rm-dist
Flag --rm-dist has been deprecated, please use --clean instead
  • starting release...
  ⨯ release failed after 0s                  error=yaml: unmarshal errors:
  line 17: field replacements not found in type config.Archive
Error: The process '/opt/hostedtoolcache/goreleaser-action/1.25.1/x64/goreleaser' failed with exit code 1
```

To resolve the error, this pull request replaces the deprecated field `replacements` with `name_templates`.

https://goreleaser.com/deprecations/?h=replacements#nfpmsmaintainer_1
